### PR TITLE
Fix control

### DIFF
--- a/__tests__/lexer/getControlChar.js
+++ b/__tests__/lexer/getControlChar.js
@@ -321,20 +321,20 @@ describe("getControlChar", () => {
                 {
                     quantifier: "exactlyOne",
                     regex: "\\",
-                    type: "element",
+                    type: "literal",
+                    value: "\\",
+                },
+                {
+                    quantifier: "exactlyOne",
+                    regex: "\\",
+                    type: "literal",
                     value: "\\",
                 },
                 {
                     quantifier: "exactlyOne",
                     regex: "c",
-                    type: "element",
+                    type: "literal",
                     value: "c",
-                },
-                {
-                    quantifier: "exactlyOne",
-                    regex: "7",
-                    type: "element",
-                    value: "7",
                 }
             ]
         );

--- a/__tests__/lexer/handleRange.js
+++ b/__tests__/lexer/handleRange.js
@@ -10,14 +10,7 @@ describe("handleRange", () => {
         };
         const betweenBraces = "3,";
         const index = 2;
-        const expectedIndex = index + betweenBraces.length + 1;
-        const expectedToken = {
-            quantifier: "exactlyOne",
-            regex: `{${betweenBraces}}`,
-            type: "range",
-            value: "atLeast3"
-        };
-        expect(handleRange(lastElement, betweenBraces, index)).toEqual({index: expectedIndex, token: expectedToken});
+        handleRange(lastElement, betweenBraces, index);
         expect(lastElement.quantifier).toEqual("atLeast3");
     });
 });

--- a/__tests__/lexer/index.js
+++ b/__tests__/lexer/index.js
@@ -9,7 +9,7 @@ const testRegex = /[a\bc](?<=a)\c23((a)\cA)+.*(?=5)[\b]/gs;
 const regexString = testRegex.toString();
 
 // /* eslint-disable */
-const reg = /(?<=a)[123][^abc][.].+? {2}\u{12532}\cA (?=5)/gsu;
+const reg = /(?<=a)[123][^abc][.].+? {2}\u{12532}\cA {3,}(?=5)/gsu;
 
 describe("findInstancesInCharacterArray", () => {
     test("should be able to find all instances of . in character sets", () => {
@@ -121,15 +121,9 @@ describe("tokenize", () => {
                     },
                     {
                         quantifier: "exactly2",
-                        regex: " ",
+                        regex: " {2}",
                         type: "literal",
-                        value: " ",
-                    },
-                    {
-                        quantifier: "exactlyOne",
-                        regex: "{2}",
-                        type: "range",
-                        value: "exactly2",
+                        value: "\"  \"",
                     },
                     {
                         quantifier: "exactlyOne",
@@ -144,10 +138,10 @@ describe("tokenize", () => {
                         value: "startOfHeading",
                     },
                     {
-                        quantifier: "exactlyOne",
-                        regex: " ",
+                        quantifier: "atLeast3",
+                        regex: " {3,}",
                         type: "literal",
-                        value: " ",
+                        value: "\" \" repeated at least 3 times",
                     },
                     {
                         quantifier: "exactlyOne",

--- a/src/lexer/getControlChar.js
+++ b/src/lexer/getControlChar.js
@@ -211,28 +211,28 @@ const getControlChar = (controlChar) => {
         // Control characters only include
         // \ca - \cz (case insensitive)
         // So if the value after c is anything else,
-        // Match literally
+        // Match a backslash and c literally
         default: {
             return (
                 [
                     {
                         quantifier: "exactlyOne",
                         regex: "\\",
-                        type: "element",
+                        type: "literal",
+                        value: "\\",
+                    },
+                    {
+                        quantifier: "exactlyOne",
+                        regex: "\\",
+                        type: "literal",
                         value: "\\",
                     },
                     {
                         quantifier: "exactlyOne",
                         regex: "c",
-                        type: "element",
+                        type: "literal",
                         value: "c",
                     },
-                    {
-                        quantifier: "exactlyOne",
-                        regex: controlChar,
-                        type: "element",
-                        value: controlChar,
-                    }
                 ]
             );
         }

--- a/src/lexer/handleEscapes.js
+++ b/src/lexer/handleEscapes.js
@@ -172,6 +172,12 @@ const handleEscapes = ({
                 },
             };
         case "c": {
+            if (Array.isArray(getControlChar(nextChar))) {
+                return {
+                    index: index + 1,
+                    token: getControlChar(nextChar),
+                };
+            }
             return {
                 index: index + 2,
                 token: getControlChar(nextChar),

--- a/src/lexer/handleRange.js
+++ b/src/lexer/handleRange.js
@@ -23,37 +23,19 @@ const handleRange = (lastElement, betweenBraces, index) => {
         };
     } else if (isNumeric(min) && isNumeric(max)) {
         lastElement.quantifier = `${min}to${max}`;
-        return {
-            index: index + betweenBraces.length + 1,
-            token: {
-                quantifier: "exactlyOne",
-                regex: `{${betweenBraces}}`,
-                type: "range",
-                value: `${min}to${max}`
-            }
-        };
+        lastElement.regex += `{${betweenBraces}}`;
+        lastElement.value = `"${lastElement.value}" repeated at least ${min} times and no more than ${max} times`;
+        return {index: index + betweenBraces.length + 1, };
     } else if (isNumeric(min) && max === "") {
         lastElement.quantifier = `atLeast${min}`;
-        return {
-            index: index + betweenBraces.length + 1,
-            token: {
-                quantifier: "exactlyOne",
-                regex: `{${betweenBraces}}`,
-                type: "range",
-                value: `atLeast${min}`
-            }
-        };
+        lastElement.regex += `{${betweenBraces}}`;
+        lastElement.value = `"${lastElement.value}" repeated at least ${min} times`;
+        return {index: index + betweenBraces.length + 1, };
     } else if (isNumeric(min) && max === undefined) {
         lastElement.quantifier = `exactly${min}`;
-        return {
-            index: index + betweenBraces.length + 1,
-            token: {
-                quantifier: "exactlyOne",
-                regex: `{${betweenBraces}}`,
-                type: "range",
-                value: `exactly${min}`
-            }
-        };
+        lastElement.regex += `{${betweenBraces}}`;
+        lastElement.value = `"${lastElement.value.repeat(min)}"`;
+        return {index: index + betweenBraces.length + 1, };
     }
 };
 

--- a/src/lexer/index.js
+++ b/src/lexer/index.js
@@ -174,13 +174,15 @@ function tokenize(regex) {
                 const closingBrace = pattern.indexOf("}", i + 1);
                 const betweenBraces = pattern.slice(i + 1, closingBrace);
                 const lastElement = last(last(stack));
-                const { index, token } = handleRange(
+                const range = handleRange(
                     lastElement,
                     betweenBraces,
                     i + 1
                 );
-                last(stack).push(token);
-                i = index;
+                if (range.token) {
+                    last(stack).push(range.token);
+                }
+                i = range.index;
                 break;
             }
             case "[": {


### PR DESCRIPTION
<!-- First of all, thank you _so much_ for deciding to take the time to contribute to this project!  I know there are plenty of projects out there and am honored and humbled that you would take time out of your day to try to improve things here.  Thank you, really.  -->

## Describe the changes
Changes to getControlChar that match the actual evaluation.  It doesn't make sense to evaluate the character passed in that follows `\c` that isn't a control character as literal because it's possible that it's a character that needs to be reevaluated.  The only thing that needs to be evaluated literally is the `\` and the `c`.  

## Checklist
- [ x] PR modifies tests
- [ x] I have tested this solution locally
